### PR TITLE
[Docs] EZ: Adjust playground to hide mode

### DIFF
--- a/mint.json
+++ b/mint.json
@@ -8,7 +8,9 @@
         "auth": {
             "method": "bearer"
         },
-        "hidePlayground": true
+        "playground": {
+            "mode": "hide"
+        }
     },
     "favicon": "/favicon.png",
     "colors": {


### PR DESCRIPTION
# Summary

We recently adjusted the syntax of our `mint.json` to hidding playgrounds using `api.playground.mode: hide` instead of `api.hidePlayground: true`.

This PR adjusts the syntax for your current configurations